### PR TITLE
Add execute_console_command function to kafka

### DIFF
--- a/Lib/__lib_kafka__.py
+++ b/Lib/__lib_kafka__.py
@@ -45,6 +45,21 @@ def get_selected_asset_source_path(asset:object) -> str:
     source_path = unreal.EditorAssetLibrary.get_path_name(asset)
     print(source_path)
     return source_path
+
+def execute_console_command(command:str, target:str ='') -> bool:
+    '''
+    #### Description: Execute the console command
+    #### command : desired command
+    #### target : target object, normaly editor asset.
+    '''
+    dir = get_git_path() 
+    target = target.replace(dir, '')
+    execute_command = command + ' ' + target
+    print('Command : ' + execute_command)
+    process = subprocess.Popen(execute_command, stdout=subprocess.PIPE, shell=True, cwd=dir)
+    output, error = process.communicate()
+    print(output)
+    
      
 def lock_asset(asset:str) -> None:
     '''
@@ -66,4 +81,3 @@ def unlock_asset(asset:str) -> None:
     output, error = process.communicate()
     print(output)
  
-

--- a/Material_Edit/recompile_material.py
+++ b/Material_Edit/recompile_material.py
@@ -1,0 +1,9 @@
+import unreal, importlib
+from Lib import __lib_topaz__ as topaz
+importlib.reload(topaz)
+
+selected = topaz.get_selected_assets()
+
+for asset in selected:
+    unreal.MaterialEditingLibrary.recompile_material(asset)
+    pass

--- a/SourceControl/safe_add.py
+++ b/SourceControl/safe_add.py
@@ -1,0 +1,14 @@
+from Lib import __lib_topaz__ as topaz
+from Lib import __lib_kafka__ as kafka
+import importlib
+
+importlib.reload(topaz)
+importlib.reload(kafka)
+
+selected = topaz.get_selected_assets() 
+
+for asset in selected :
+    asset_path = topaz.get_selected_asset_source_path(asset)
+    asset_path = topaz.remap_uepath_to_filepath(asset_path)
+    kafka.execute_console_command('git add', asset_path)
+

--- a/__TestCode__/__temp__.py
+++ b/__TestCode__/__temp__.py
@@ -1,11 +1,11 @@
 import unreal
 import importlib
 from Lib import __lib_topaz__ as topaz
+from Lib import __lib_kafka__ as kafka
 
-importlib.reload(topaz)
+selected = topaz.get_selected_asset()
 
-#topaz.get_selected_assets()
+print(selected.__class__)
 
-selected = topaz.get_selected_level_actor()
 
-topaz.get_actor_bound_size(selected)
+unreal.AssetToolsHelpers.get_asset_tools().redire


### PR DESCRIPTION
This pull request adds the `execute_console_command` function to the kafka module. The function allows for executing console commands with a target object, typically an editor asset.