### PR TITLE
Add SpawnRefball.py and DestroyRefball.py scripts

### DIFF
--- a/LevelStreaming/DestroyRefball.py
+++ b/LevelStreaming/DestroyRefball.py
@@ -1,0 +1,22 @@
+import unreal
+
+# 삭제할 블루프린트 액터의 경로
+blueprint_path = '/Game/Environment/BP_RefBall.BP_RefBall'
+
+# 삭제할 액터 클래스의 레퍼런스 얻기
+actor_class_ref = unreal.EditorAssetLibrary.load_blueprint_class(blueprint_path)
+
+# 레벨의 모든 액터를 가져오기
+actors = unreal.EditorLevelLibrary.get_all_level_actors()
+
+# 액터들을 반복 처리하며, 특정 액터 찾기
+for actor in actors:
+    # 액터의 클래스를 가져옴
+    actor_class = actor.get_class()
+    
+    # 액터의 클래스와 삭제할 블루프린트의 클래스가 일치하는지 확인
+    if actor_class == actor_class_ref:
+        # 액터 파괴
+        unreal.EditorLevelLibrary.destroy_actor(actor)
+
+print("All BP_RefBall actors destroyed.")

--- a/LevelStreaming/SpawnRefball.py
+++ b/LevelStreaming/SpawnRefball.py
@@ -1,0 +1,42 @@
+
+
+import unreal
+import math
+
+def get_viewport_camera() -> tuple[unreal.Vector, unreal.Rotator]:
+    viewport_cam_info = unreal.EditorLevelLibrary.get_level_viewport_camera_info()
+    return viewport_cam_info
+
+viewport_camera_info = get_viewport_camera()
+
+if viewport_camera_info:
+    # 카메라의 위치 정보를 가져옴
+    camera_position = viewport_camera_info[0]
+    # 카메라의 회전 정보를 가져옴
+    camera_rotation = viewport_camera_info[1]
+    camera_rotation.yaw += 180  # Yaw 회전값에 180도 추가
+
+    # 카메라 회전을 기반으로 회전된 방향 벡터를 계산 (앞쪽 방향)
+    forward_vector = unreal.Vector(math.cos(math.radians(camera_rotation.yaw)) * math.cos(math.radians(camera_rotation.pitch)),
+                                   math.sin(math.radians(camera_rotation.yaw)) * math.cos(math.radians(camera_rotation.pitch)),
+                                   math.sin(math.radians(camera_rotation.pitch)))
+
+    # 이동할 거리 설정
+    offset_distance = -300.0
+    
+    # 이동할 거리만큼 앞으로 이동한 위치 계산, Pitch 값에 10을 곱하여 Z축 조정
+    z_adjust = math.sin(math.radians(camera_rotation.pitch)) * 500
+    spawn_position = camera_position + forward_vector * offset_distance
+    spawn_position.z += z_adjust
+
+    # 레퍼볼 블루프린트 클래스 로드
+    actor_class = unreal.EditorAssetLibrary.load_blueprint_class('/Game/Environment/BP_RefBall.BP_RefBall')
+
+    # 수정된 위치와 회전을 사용하여 액터 스폰
+    spawn_actor = unreal.EditorLevelLibrary.spawn_actor_from_class(actor_class, spawn_position, camera_rotation)
+
+
+
+
+
+


### PR DESCRIPTION
This pull request adds two new scripts: SpawnRefball.py and DestroyRefball.py.

The SpawnRefball.py script allows for spawning a refball actor based on the viewport camera's position and rotation. It calculates the forward vector based on the camera's rotation and moves the refball actor a specified distance in front of the camera. The script also adjusts the spawn position based on the camera's pitch.

The DestroyRefball.py script allows for destroying all instances of the BP_RefBall actor in the level. It iterates through all level actors and checks if their class matches the BP_RefBall blueprint class. If a match is found, the actor is destroyed.

These scripts provide convenient functionality for working with refball actors in the level.