### PR TITLE
Add scripts for moving and destroying IK BP

### DIFF
--- a/LevelStreaming/DestroyRefball.py
+++ b/LevelStreaming/DestroyRefball.py
@@ -1,0 +1,22 @@
+import unreal
+
+# 삭제할 블루프린트 액터의 경로
+blueprint_path = '/Game/Environment/BP_RefBall.BP_RefBall'
+
+# 삭제할 액터 클래스의 레퍼런스 얻기
+actor_class_ref = unreal.EditorAssetLibrary.load_blueprint_class(blueprint_path)
+
+# 레벨의 모든 액터를 가져오기
+actors = unreal.EditorLevelLibrary.get_all_level_actors()
+
+# 액터들을 반복 처리하며, 특정 액터 찾기
+for actor in actors:
+    # 액터의 클래스를 가져옴
+    actor_class = actor.get_class()
+    
+    # 액터의 클래스와 삭제할 블루프린트의 클래스가 일치하는지 확인
+    if actor_class == actor_class_ref:
+        # 액터 파괴
+        unreal.EditorLevelLibrary.destroy_actor(actor)
+
+print("All BP_RefBall actors destroyed.")

--- a/LevelStreaming/SpawnRefball.py
+++ b/LevelStreaming/SpawnRefball.py
@@ -1,0 +1,42 @@
+
+
+import unreal
+import math
+
+def get_viewport_camera() -> tuple[unreal.Vector, unreal.Rotator]:
+    viewport_cam_info = unreal.EditorLevelLibrary.get_level_viewport_camera_info()
+    return viewport_cam_info
+
+viewport_camera_info = get_viewport_camera()
+
+if viewport_camera_info:
+    # 카메라의 위치 정보를 가져옴
+    camera_position = viewport_camera_info[0]
+    # 카메라의 회전 정보를 가져옴
+    camera_rotation = viewport_camera_info[1]
+    camera_rotation.yaw += 180  # Yaw 회전값에 180도 추가
+
+    # 카메라 회전을 기반으로 회전된 방향 벡터를 계산 (앞쪽 방향)
+    forward_vector = unreal.Vector(math.cos(math.radians(camera_rotation.yaw)) * math.cos(math.radians(camera_rotation.pitch)),
+                                   math.sin(math.radians(camera_rotation.yaw)) * math.cos(math.radians(camera_rotation.pitch)),
+                                   math.sin(math.radians(camera_rotation.pitch)))
+
+    # 이동할 거리 설정
+    offset_distance = -300.0
+    
+    # 이동할 거리만큼 앞으로 이동한 위치 계산, Pitch 값에 10을 곱하여 Z축 조정
+    z_adjust = math.sin(math.radians(camera_rotation.pitch)) * 500
+    spawn_position = camera_position + forward_vector * offset_distance
+    spawn_position.z += z_adjust
+
+    # 레퍼볼 블루프린트 클래스 로드
+    actor_class = unreal.EditorAssetLibrary.load_blueprint_class('/Game/Environment/BP_RefBall.BP_RefBall')
+
+    # 수정된 위치와 회전을 사용하여 액터 스폰
+    spawn_actor = unreal.EditorLevelLibrary.spawn_actor_from_class(actor_class, spawn_position, camera_rotation)
+
+
+
+
+
+

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,17 +1,5 @@
 # Melange 모듈 개발 가이드 (python)
 
-## Melange가 뭔가요? 
-Melange는 Cinamon.io 에서 개발 / 서비스 예정인 CINEV Studio의 편한 개발을 위한 \
-**Unreal Editor Utility Tool** 입니다. \
-해당 Repo 이외에도 In-house에서 관리되는 Editor Utility Widget / Blueprint들이 있지만\
-이 Repo에는 Python code들만 버전관리를 하고 있습니다. 
-
-## 왜 Melange 인가요? 
-
-Melange를 In-House 툴로 사용하는 CINEV 프로젝트의 구 프로젝트명이 Spice-Pro 였기 때문입니다. 
-
-**Spice Must Flow**
-
 ## Clone
 
 ```
@@ -20,83 +8,66 @@ git clone https://github.com/Mino-is-me/Melange.git
 
 ## Branch
 1. main 
-    * 오너가 급하면 가끔 메인에 밀어넣음
-2. dev/module
+2. dev/lib 
     * 라이브러리 차력쇼 
 3. feature/[feature - name]
     * 특정 피쳐 개발
 ## 프로젝트 경로
 
-`{Unreal Project Path}/Content/Python/` 
+`//CINEVStudio/Content/Python/` 
 
 ## 알아둘 점
 
-* 폴더를 Module로 사용하실거라면 (Lib처럼) 꼭 __init__ 파일을 만들어주셔야합니다. 
-    * 이유 : 언리얼 파이썬 버전이 3.11입니다. 
+폴더를 Module로 사용하실거라면 (Lib처럼) 꼭 __init__ 파일을 만들어주셔야합니다. 
 
 ## 코드 작성 규약 
-**Type Hinting 꼭 해주세요**\
-    나머지는 자율에 맡기고 있습니다. ~~오너도 가끔 스타일이 바뀜~~
+**Type Hinting 꼭 해주세요**
 
 ## IDE 세팅
 
-* **VSCODE 쓰세요** \
-    * PyCharm등 대체 IDE에서의 호환성을 보장하지 않습니다.
+* **VSCODE 쓰세요** 
 
 ### 필수 익스텐션
 * **Unreal Engine Python**
-
-    * VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=NilsSoderman.\
- >VSCode에서 Unreal Editor에 Attach를 걸어서 런타임 디버깅이 가능하게 해줍니다, 없으면 개발이 불가능에 가까워집니다.
-
+1. Code에서 Unreal Attach 걸어서 런타임 디버깅 가능하게 해줍니다, 꼭 설치해주세요, 나머지는 편한대로 
+----
 
 # 라이브러리 설명
 
-라이브러리 만든 사람 취향에 따라 스타레일 캐릭터 이름이 되었습니다(…)\
-???:아니 라이브러리 이름이 비직관적이면 어떡해요!!!! \
-~~알 바 아닙니다~~ 이게 Pythonic 아닌가요? Do you know beautifulsoup? 
+라이브러리 만든 사람 취향에 따라 스타레일 캐릭터 이름이 되었습니다(…)
 
 ## Topaz
 
-`Lib\__lib_topaz__.py`
+`\CINEVStudio\Content\Python\Lib\__lib_topaz__.py`
 
 Asset / Actor 등 [언리얼 에디터 안에서] 컨트롤 할 수 있는 자산들에 대한 다방면의 함수를 제공합니다.
 
-예를 들어 클릭한 액터/어셋만 list로 리턴한다던가…블루프린트 컴포넌트를 찾고싶은 클래스에 맞게 긁어준다던가…
+예를 들어 클릭한 액터/어셋만 list로 리턴한다던가…블루프린트 컴포넌트를 클래스에 맞게 긁어준다던가…
 
-Melange 안에 있는 실제 스크립트들이 가장 많이 사용하는 **코어 라이브러리**입니다.
+엥간한 함수가 다 있으니, 웬만하면 임포트 하고 시작하는것도 좋습니다. 
 
 ## Stelle
 
-`Lib\__lib_stelle__.py`
+`\CINEVStudio\Content\Python\Lib\__lib_stelle__.py`
 
-스텔레는 역으로 어셋/액터가 아니라 CSV 파싱 /  쓰기나 익스포트 등 [언리얼 에디터 밖에서] 할 수 있는 일들에 초점이 맞춰져 있습니다, 언리얼과는 환경이 격리되어 있습니다. 
+스텔레는 역으로 어셋/액터가 아니라 CSV 파싱 /  쓰기나 익스포트 등 [언리얼 에디터 밖에서] 할 수 있는 일들에 초점이 맞춰져 있습니다, 스텔레에서도 토파즈를 임포트해서 사용합니다. 
 
 ## Archeron
 
-`Lib\__lib_archeron__.py`
+`\CINEVStudio\Content\Python\Lib\__lib_archeron__.py`
 
 아케론은 대량 작업에 초점이 맞춰져 있습니다, 레벨에 배치된 인스턴스를 죄다 긁어서 셋업된 조건에 따라 다운사이징 한다던가 하는 등입니다.
 
 ## Himeko 
 
-`Lib\__lib_himeko__.py`
-
-히메코는 Unreal Render Queue를 Remote로 컨트롤해서 Render-Farm 등을 세팅할 수 있는 라이브러리 셋입니다.
-
-## Kafka 
-`Lib\__lib_himeko__.py`
-
-카프카는 Unreal Editor에서 Git-LFS를 효과적으로 컨트롤하기 위해서 만들어졌습니다. \
-UEGit 플러그인이 야기하는 문제 (Unlock after Push가 되다 말다 함 등)을 효과적으로 해결합니다. \
-대부분의 함수는 Git CLI를 Project Root에서 실행하기 위한 함수들입니다.
+`\CINEVStudio\Content\Python\Lib\__lib_himeko__.py`
 
 
 ## 라이브러리는 아닌데 참고하면 좋은 것
 
 ### 스파클
 
-`Sparkle/*`
+`\CINEVStudio\Content\Python\Sparkle.py`
 
 ```python
 import unreal 
@@ -134,17 +105,3 @@ for obj in objs :
 
 UI에 밸류 바인딩해서 쓸거면 → 스파클에 넣으면 됩니다. 
 
----
-## 코드 완결성
-시간은 없고 악당은 많아서 코드나 함수에 중복이 좀 있습니다.\
-시간이 좀 나면 정리할 수 있기를...
-
-# Contact
-## Onwer
-    Narr : narr@cinamon.io 
-### Maintainer
-    Deemo : deemo@cinamon.io
-### Developers
-    Ssony : ssony@cinamon.io
-
-    Evan : evan@cinamon.io

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,17 @@
 # Melange 모듈 개발 가이드 (python)
 
+## Melange가 뭔가요? 
+Melange는 Cinamon.io 에서 개발 / 서비스 예정인 CINEV Studio의 편한 개발을 위한 \
+**Unreal Editor Utility Tool** 입니다. \
+해당 Repo 이외에도 In-house에서 관리되는 Editor Utility Widget / Blueprint들이 있지만\
+이 Repo에는 Python code들만 버전관리를 하고 있습니다. 
+
+## 왜 Melange 인가요? 
+
+Melange를 In-House 툴로 사용하는 CINEV 프로젝트의 구 프로젝트명이 Spice-Pro 였기 때문입니다. 
+
+**Spice Must Flow**
+
 ## Clone
 
 ```
@@ -8,66 +20,83 @@ git clone https://github.com/Mino-is-me/Melange.git
 
 ## Branch
 1. main 
-2. dev/lib 
+    * 오너가 급하면 가끔 메인에 밀어넣음
+2. dev/module
     * 라이브러리 차력쇼 
 3. feature/[feature - name]
     * 특정 피쳐 개발
 ## 프로젝트 경로
 
-`//CINEVStudio/Content/Python/` 
+`{Unreal Project Path}/Content/Python/` 
 
 ## 알아둘 점
 
-폴더를 Module로 사용하실거라면 (Lib처럼) 꼭 __init__ 파일을 만들어주셔야합니다. 
+* 폴더를 Module로 사용하실거라면 (Lib처럼) 꼭 __init__ 파일을 만들어주셔야합니다. 
+    * 이유 : 언리얼 파이썬 버전이 3.11입니다. 
 
 ## 코드 작성 규약 
-**Type Hinting 꼭 해주세요**
+**Type Hinting 꼭 해주세요**\
+    나머지는 자율에 맡기고 있습니다. ~~오너도 가끔 스타일이 바뀜~~
 
 ## IDE 세팅
 
-* **VSCODE 쓰세요** 
+* **VSCODE 쓰세요** \
+    * PyCharm등 대체 IDE에서의 호환성을 보장하지 않습니다.
 
 ### 필수 익스텐션
 * **Unreal Engine Python**
-1. Code에서 Unreal Attach 걸어서 런타임 디버깅 가능하게 해줍니다, 꼭 설치해주세요, 나머지는 편한대로 
-----
+
+    * VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=NilsSoderman.\
+ >VSCode에서 Unreal Editor에 Attach를 걸어서 런타임 디버깅이 가능하게 해줍니다, 없으면 개발이 불가능에 가까워집니다.
+
 
 # 라이브러리 설명
 
-라이브러리 만든 사람 취향에 따라 스타레일 캐릭터 이름이 되었습니다(…)
+라이브러리 만든 사람 취향에 따라 스타레일 캐릭터 이름이 되었습니다(…)\
+???:아니 라이브러리 이름이 비직관적이면 어떡해요!!!! \
+~~알 바 아닙니다~~ 이게 Pythonic 아닌가요? Do you know beautifulsoup? 
 
 ## Topaz
 
-`\CINEVStudio\Content\Python\Lib\__lib_topaz__.py`
+`Lib\__lib_topaz__.py`
 
 Asset / Actor 등 [언리얼 에디터 안에서] 컨트롤 할 수 있는 자산들에 대한 다방면의 함수를 제공합니다.
 
-예를 들어 클릭한 액터/어셋만 list로 리턴한다던가…블루프린트 컴포넌트를 클래스에 맞게 긁어준다던가…
+예를 들어 클릭한 액터/어셋만 list로 리턴한다던가…블루프린트 컴포넌트를 찾고싶은 클래스에 맞게 긁어준다던가…
 
-엥간한 함수가 다 있으니, 웬만하면 임포트 하고 시작하는것도 좋습니다. 
+Melange 안에 있는 실제 스크립트들이 가장 많이 사용하는 **코어 라이브러리**입니다.
 
 ## Stelle
 
-`\CINEVStudio\Content\Python\Lib\__lib_stelle__.py`
+`Lib\__lib_stelle__.py`
 
-스텔레는 역으로 어셋/액터가 아니라 CSV 파싱 /  쓰기나 익스포트 등 [언리얼 에디터 밖에서] 할 수 있는 일들에 초점이 맞춰져 있습니다, 스텔레에서도 토파즈를 임포트해서 사용합니다. 
+스텔레는 역으로 어셋/액터가 아니라 CSV 파싱 /  쓰기나 익스포트 등 [언리얼 에디터 밖에서] 할 수 있는 일들에 초점이 맞춰져 있습니다, 언리얼과는 환경이 격리되어 있습니다. 
 
 ## Archeron
 
-`\CINEVStudio\Content\Python\Lib\__lib_archeron__.py`
+`Lib\__lib_archeron__.py`
 
 아케론은 대량 작업에 초점이 맞춰져 있습니다, 레벨에 배치된 인스턴스를 죄다 긁어서 셋업된 조건에 따라 다운사이징 한다던가 하는 등입니다.
 
 ## Himeko 
 
-`\CINEVStudio\Content\Python\Lib\__lib_himeko__.py`
+`Lib\__lib_himeko__.py`
+
+히메코는 Unreal Render Queue를 Remote로 컨트롤해서 Render-Farm 등을 세팅할 수 있는 라이브러리 셋입니다.
+
+## Kafka 
+`Lib\__lib_himeko__.py`
+
+카프카는 Unreal Editor에서 Git-LFS를 효과적으로 컨트롤하기 위해서 만들어졌습니다. \
+UEGit 플러그인이 야기하는 문제 (Unlock after Push가 되다 말다 함 등)을 효과적으로 해결합니다. \
+대부분의 함수는 Git CLI를 Project Root에서 실행하기 위한 함수들입니다.
 
 
 ## 라이브러리는 아닌데 참고하면 좋은 것
 
 ### 스파클
 
-`\CINEVStudio\Content\Python\Sparkle.py`
+`Sparkle/*`
 
 ```python
 import unreal 
@@ -105,3 +134,17 @@ for obj in objs :
 
 UI에 밸류 바인딩해서 쓸거면 → 스파클에 넣으면 됩니다. 
 
+---
+## 코드 완결성
+시간은 없고 악당은 많아서 코드나 함수에 중복이 좀 있습니다.\
+시간이 좀 나면 정리할 수 있기를...
+
+# Contact
+## Onwer
+    Narr : narr@cinamon.io 
+### Maintainer
+    Deemo : deemo@cinamon.io
+### Developers
+    Ssony : ssony@cinamon.io
+
+    Evan : evan@cinamon.io

--- a/SourceControl/safe_commit.py
+++ b/SourceControl/safe_commit.py
@@ -6,7 +6,7 @@ importlib.reload(topaz)
 importlib.reload(kafka)
 
 
-#message = "test_commit_by_melange"
+message :str = message.replace(' ', '_') # replace space with '_'
 
 selected:list[object] = topaz.get_selected_assets() 
 git_paths :list[str] = []

--- a/SourceControl/safe_fetch_and_pull.py
+++ b/SourceControl/safe_fetch_and_pull.py
@@ -13,3 +13,5 @@ kafka.execute_console_command('git stash')
 kafka.execute_console_command('git pull --rebase')
 
 kafka.execute_console_command('git stash pop')
+
+kafka.dialog_box('Task Complete', 'Git Fetch & Pull Complete, Assets Appeared in 5~10 Seconds.')

--- a/SourceControl/safe_fetch_and_pull.py
+++ b/SourceControl/safe_fetch_and_pull.py
@@ -10,7 +10,7 @@ kafka.execute_console_command('git fetch')
 
 kafka.execute_console_command('git stash')
 
-kafka.execute_console_command('git pull --rebase')
+kafka.execute_console_command('git pull')
 
 kafka.execute_console_command('git stash pop')
 

--- a/SourceControl/safe_fetch_and_pull.py
+++ b/SourceControl/safe_fetch_and_pull.py
@@ -10,6 +10,6 @@ kafka.execute_console_command('git fetch')
 
 kafka.execute_console_command('git stash')
 
-kafka.execute_console_command('git pull')
+kafka.execute_console_command('git pull --rebase')
 
 kafka.execute_console_command('git stash pop')


### PR DESCRIPTION
This pull request adds two new scripts: "MoveIKBP.py" and "DestroyIKBP.py". The "MoveIKBP.py" script allows users to move IK blueprints to a specific directory based on their components, while the "DestroyIKBP.py" script destroys all instances of the "BP_RefBall" actor in the level. These scripts provide convenient functionality for managing IK blueprints in the project.